### PR TITLE
fix a link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
      Download RVM and install Ruby: curl -L https://get.rvm.io | bash -s stable --ruby
      
 ## Lambdatest Credentials
-   * Set LambdaTest username and access key in environment variables. It can be obtained from [LambdaTest dashboard]   (https://automation.lambdatest.com/)     
+   * Set LambdaTest username and access key in environment variables. It can be obtained from [LambdaTest dashboard](https://automation.lambdatest.com/)     
    
    example:
  * For linux/mac    


### PR DESCRIPTION
the space between the square bracket and the parenthesis prevented Github to render the link correctly